### PR TITLE
Better server + bug workaround

### DIFF
--- a/scrape/jist2youtube.js
+++ b/scrape/jist2youtube.js
@@ -1,6 +1,5 @@
 "use strict";
-
-var server = 'replace with your server address';
+var server = process.env.SERVER;
 
 var googleCredentials = require('../data/googleCredentials.json');
 


### PR DESCRIPTION
I put here all i done last hours.
Now you just need to add environment variable SERVER in heroku!
https://i.gyazo.com/3843a41b664243d20bd08b93f7452a4c.png **example**
Also i add my workarounds for bugs which i needed to be overcome.
There is some bug with casperjs i believe.
If you have multiple arguments `na:player na:player1 na:player2` loop will process only last argument multiple `casper.cli.args.length` times!
In my case need just pull casperjs part to outer function and all fine.
Like it done in record.js -> https://i.gyazo.com/3113e7fe2cbdcd4afa46aa546b1d5bbf.png
Hope its help to make app more ready for public!

I'm planning make some work with summoners name bc some exotic names can't process like BoxBox's summoner "잘 못" but encodeURI can done work here. 
https://i.gyazo.com/925f58649c3cb43b48b3f8e816f4cbc1.png -> and it work with op.gg
But not really know how it `%EC%9E%98%EB%AA%BB` will process after on jits and yt.