### PR TITLE
Json trick

### DIFF
--- a/scrape/op2jist.js
+++ b/scrape/op2jist.js
@@ -123,11 +123,14 @@ function getRecordedMatches(regionCode, userName, getAll) {
         casper.thenLazyOpen(url_id, function _getSummonerId() {
             casper.evaluate(function() { // error: TypeError: undefined is not an object (evaluating 'JSON.parse(this.getPageContent())' WORKAROUND
 		var json_object = JSON.parse(this.getPageContent());
-		var json_array = [];
-		for(var x in json_object){
-		    arr.push(json_object[x]);
+		var firstProp;
+		for(var key in json_object) {
+    		    if(json_object.hasOwnProperty(key)) {
+        	        firstProp = json_object[key];
+                        break;
+    		    }
 		}
-		var summonerId = json_array[0][1]['id'];
+		var summonerId = firstProp['id'];
                 var lanesLookupMap = {};
 
                 // create lookup map

--- a/scrape/op2jist.js
+++ b/scrape/op2jist.js
@@ -122,7 +122,12 @@ function getRecordedMatches(regionCode, userName, getAll) {
                 
         casper.thenLazyOpen(url_id, function _getSummonerId() {
             casper.evaluate(function() { // error: TypeError: undefined is not an object (evaluating 'JSON.parse(this.getPageContent())' WORKAROUND
-                var summonerId = JSON.parse(this.getPageContent())[userName]['id'];
+				var json_object = JSON.parse(this.getPageContent());
+				var json_array = [];
+				for(var x in json_object){
+					arr.push(json_object[x]);
+				}
+				var summonerId = json_array[0][1]['id'];
                 var lanesLookupMap = {};
 
                 // create lookup map

--- a/scrape/op2jist.js
+++ b/scrape/op2jist.js
@@ -122,12 +122,12 @@ function getRecordedMatches(regionCode, userName, getAll) {
                 
         casper.thenLazyOpen(url_id, function _getSummonerId() {
             casper.evaluate(function() { // error: TypeError: undefined is not an object (evaluating 'JSON.parse(this.getPageContent())' WORKAROUND
-				var json_object = JSON.parse(this.getPageContent());
-				var json_array = [];
-				for(var x in json_object){
-					arr.push(json_object[x]);
-				}
-				var summonerId = json_array[0][1]['id'];
+		var json_object = JSON.parse(this.getPageContent());
+		var json_array = [];
+		for(var x in json_object){
+		    arr.push(json_object[x]);
+		}
+		var summonerId = json_array[0][1]['id'];
                 var lanesLookupMap = {};
 
                 // create lookup map


### PR DESCRIPTION
Hello!
There is only one reason for this update.
Let's say the name of the summoner consists of two or more words `na:Annie Bot`
First of all, that such a name does not violate the program at all, it must be enclosed in quotes
`na:'Annie Bot'` now its fine, also this not break jits.tv part when it fill selector with userName while upload
Now we have problem with riot api json there is why:

- {"**_anniebot_**":{"id":blahblah,"name":"Annie Bot"...
But our var userName == Annie Bot
There is a space ( ╯°□°)╯ ┻━━┻

- So we find first property and access `id = firstProp['id'];`

Sorry if there is some retaded TABs in code... notepad++ doesn's save it properly.
